### PR TITLE
コンパイルエラーを修正

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -35,17 +35,6 @@
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
-				
-		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-boot-starter</artifactId>
-			<version>3.0.0</version>
-		</dependency>
-		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-spring-web</artifactId>
-			<version>3.0.0</version>
-		</dependency>
 		<dependency>
 			<groupId>io.swagger.parser.v3</groupId>
 			<artifactId>swagger-parser</artifactId>
@@ -59,6 +48,11 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>${project.build.directory}/generated-sources/openapi/src/main/resources</directory>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
動作できるように調整しました。次の対応を行っています。
* spring-foxの依存性を削除
* 生成したプロジェクトのリソースフォルダをビルド対象として追加

上記の対応でSpringFoxを使用したい場合は別途対応が必要です。SpringFoxは使う想定でしょうか？
ちなみにSpringFox代用としてSpringDocというライブラリも存在するようです（動作未確認）

また、SpringFoxを使用したい場合は、以下の対応で使うことができるようです（動作未確認）
ただSpringBootActuatorが使用できなくなると書いてあるので、おすすめできないです。
https://stackoverflow.com/questions/70036953/springboot-2-6-0-spring-fox-3-failed-to-start-bean-documentationpluginsboot